### PR TITLE
Update telemetry-domains_beta.txt

### DIFF
--- a/telemetry-domains_beta.txt
+++ b/telemetry-domains_beta.txt
@@ -20,6 +20,5 @@ profile.gc.apple.com
 sa.apple.com
 smp-device-content.apple.com
 ssl.google-analytics.com
-ssl.google−analytics.com
 static.gc.apple.com
 www.googleadservices.com


### PR DESCRIPTION
Removed ssl.google−analytics.com domain as it is being marked as invalid by pihole (probably due to the − symbol)